### PR TITLE
Fix Spotlight dictionary glitches

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -22,7 +22,7 @@
     if(args.count != 0) {
         NSString *executablePath = args[0];
         if(executablePath) {      
-            BOOL isApplication = [executablePath rangeOfString:@"/Application"].location != NSNotFound;
+            BOOL isApplication = [executablePath rangeOfString:@"/Application"].location != NSNotFound && [executablePath rangeOfString:@"Spotlight"].location == NSNotFound; // Fix Spotlight dictionary glitches
             if(isApplication) {
                %init(Inject);
             }


### PR DESCRIPTION
- Added a condition to the `isApplication` boolean to stop the tweak from injecting into Spotlight, to fix some weird Spotlight dictionary view glitches. 